### PR TITLE
Add dictionary type to percent encoding

### DIFF
--- a/Sources/Networking/NetworkingRequest.swift
+++ b/Sources/Networking/NetworkingRequest.swift
@@ -144,7 +144,7 @@ public class NetworkingRequest: NSObject {
         if httpVerb != .get && multipartData == nil {
             switch parameterEncoding {
             case .urlEncoded:
-                request.httpBody = percentEncodedString().data(using: .utf8)
+                request.httpBody = params.asPercentEncodedString().data(using: .utf8)
             case .json:
                 let jsonData = try? JSONSerialization.data(withJSONObject: params)
                 request.httpBody = jsonData
@@ -173,23 +173,6 @@ public class NetworkingRequest: NSObject {
             }
             .reduce(Data.init(), +)
             + boundaryEnding
-    }
-    
-    func percentEncodedString() -> String {
-        return params.map { key, value in
-            let escapedKey = "\(key)".addingPercentEncoding(withAllowedCharacters: .urlQueryValueAllowed) ?? ""
-            if let array = value as? [CustomStringConvertible] {
-                return array.map { entry in
-                    let escapedValue = "\(entry)"
-                        .addingPercentEncoding(withAllowedCharacters: .urlQueryValueAllowed) ?? ""
-                    return "\(key)[]=\(escapedValue)" }.joined(separator: "&"
-                    )
-            } else {
-                let escapedValue = "\(value)".addingPercentEncoding(withAllowedCharacters: .urlQueryValueAllowed) ?? ""
-                return "\(escapedKey)=\(escapedValue)"
-            }
-        }
-        .joined(separator: "&")
     }
 }
 

--- a/Sources/Networking/Params.swift
+++ b/Sources/Networking/Params.swift
@@ -8,3 +8,28 @@
 import Foundation
 
 public typealias Params = [String: CustomStringConvertible]
+    
+extension Params {
+    public func asPercentEncodedString(parentKey: String? = nil) -> String {
+        return self.map { key, value in
+            var escapedKey = "\(key)".addingPercentEncoding(withAllowedCharacters: .urlQueryValueAllowed) ?? ""
+            if let `parentKey` = parentKey {
+                escapedKey = "\(parentKey)[\(escapedKey)]"
+            }
+
+            if let dict = value as? Params {
+                return dict.asPercentEncodedString(parentKey: escapedKey)
+            } else if let array = value as? [CustomStringConvertible] {
+                return array.map { entry in
+                    let escapedValue = "\(entry)"
+                        .addingPercentEncoding(withAllowedCharacters: .urlQueryValueAllowed) ?? ""
+                    return "\(escapedKey)[]=\(escapedValue)"
+                }.joined(separator: "&")
+            } else {
+                let escapedValue = "\(value)".addingPercentEncoding(withAllowedCharacters: .urlQueryValueAllowed) ?? ""
+                return "\(escapedKey)=\(escapedValue)"
+            }
+        }
+        .joined(separator: "&")
+    }
+}

--- a/Tests/NetworkingTests/ParamsTests.swift
+++ b/Tests/NetworkingTests/ParamsTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+import Networking
+
+final class ParamsTests: XCTestCase {
+
+    func testAsPercentEncodedString() {
+        // Simple key value encoding
+        XCTAssertEqual("key=value", ["key": "value"].asPercentEncodedString())
+        
+        // Array-based key value encoding
+        XCTAssertEqual("key[]=value1&key[]=value2", ["key": ["value1", "value2"]].asPercentEncodedString())
+        
+        // Dictionary-based key value encoding
+        XCTAssertEqual("key[subkey1]=value1", ["key": ["subkey1": "value1"]].asPercentEncodedString())
+    }
+}


### PR DESCRIPTION
This PR fixes #30 by adding the ability to encode nested dictionary objects in the following format:

`key[subkey1]=value1&...`