### PR TITLE
Fixed the double encoding problem and used a method from Params Extensions

### DIFF
--- a/Sources/Networking/NetworkingRequest.swift
+++ b/Sources/Networking/NetworkingRequest.swift
@@ -135,27 +135,24 @@ public class NetworkingRequest: NSObject, URLSessionTaskDelegate {
     
     private func getURLWithParams() -> String {
         let urlString = baseURL + route
-        if params.isEmpty { return urlString }
-        guard let url = URL(string: urlString) else {
+        guard !params.isEmpty, let url = URL(string: urlString) else {
             return urlString
         }
-        if var urlComponents = URLComponents(url: url ,resolvingAgainstBaseURL: false) {
-            var queryItems = urlComponents.queryItems ?? [URLQueryItem]()
-            params.forEach { param in
-                // arrayParam[] syntax
-                if let array = param.value as? [CustomStringConvertible] {
-                    array.forEach {
-                        queryItems.append(URLQueryItem(name: "\(param.key)[]", value: "\($0)"))
-                    }
-                }
-                queryItems.append(URLQueryItem(name: param.key, value: "\(param.value)"))
-            }
-            urlComponents.queryItems = queryItems
-            return urlComponents.url?.absoluteString ?? urlString
+
+        guard var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return urlString
         }
-        return urlString
+
+        urlComponents.queryItems = params.map { key, value in
+            URLQueryItem(name: key, value: "\(value)")
+        }
+
+        let query = params.asPercentEncodedString()
+        urlComponents.percentEncodedQuery = query
+
+        return urlComponents.url?.absoluteString ?? urlString
     }
-    
+
     internal func buildURLRequest() -> URLRequest? {
         var urlString = baseURL + route
         if httpMethod == .get {


### PR DESCRIPTION
When building GET addresses, double decoding takes place, which is an error, so I used the extension method, you can also add an example of how to decode only single cases in getURLWithParams

```
                if let query = urlComponents.percentEncodedQuery {
                    urlComponents.percentEncodedQuery = query
                        .replacingOccurrences(of: "!", with: "%21")
                        .replacingOccurrences(of: "$", with: "%24")
                        .replacingOccurrences(of: "'", with: "%27")
                        .replacingOccurrences(of: "(", with: "%28")
                        .replacingOccurrences(of: ")", with: "%29")
                        .replacingOccurrences(of: "*", with: "%2A")
                        .replacingOccurrences(of: "+", with: "%2B")
                        .replacingOccurrences(of: ",", with: "%2C")
                        .replacingOccurrences(of: ";", with: "%3B")
                        .replacingOccurrences(of: ":", with: "%3A")
                        .replacingOccurrences(of: "#", with: "%23")
                        .replacingOccurrences(of: "[", with: "%5B")
                        .replacingOccurrences(of: "]", with: "%5D")
                        .replacingOccurrences(of: "@", with: "%40")
                }
```